### PR TITLE
Fix comment typo

### DIFF
--- a/src/Terbium/DbConfig/DbConfigServiceProvider.php
+++ b/src/Terbium/DbConfig/DbConfigServiceProvider.php
@@ -40,7 +40,7 @@ class DbConfigServiceProvider extends ServiceProvider
     public function register()
     {
 
-        // merge & publihs config
+        // merge & publish config
         $configPath = __DIR__ . '/../../../config/config.php';
         $this->mergeConfigFrom($configPath, 'db-config');
         $this->publishes([$configPath => config_path('db-config.php')]);


### PR DESCRIPTION
## Summary
- fix typo in the service provider comment

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687ad015b0a08325bc1479874ff3fd31